### PR TITLE
Allow to choose an index for tagged collection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -22,14 +22,21 @@ class TaggedIteratorArgument extends IteratorArgument
     private $indexAttribute;
     private $defaultIndexMethod;
 
+    /**
+     * TaggedIteratorArgument constructor.
+     *
+     * @param string      $tag                The name of the tag identifying the target services
+     * @param string|null $indexAttribute     The name of the attribute that defines the key referencing each service in the tagged collection
+     * @param string|null $defaultIndexMethod The static method that should be called to get each service's key when their tag doesn't define the previous attribute
+     */
     public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null)
     {
         parent::__construct([]);
 
         $this->tag = $tag;
-        $this->indexAttribute = $indexAttribute ?: null;
 
         if ($indexAttribute) {
+            $this->indexAttribute = $indexAttribute;
             $this->defaultIndexMethod = $defaultIndexMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Name');
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -19,16 +19,33 @@ namespace Symfony\Component\DependencyInjection\Argument;
 class TaggedIteratorArgument extends IteratorArgument
 {
     private $tag;
+    private $indexAttribute;
+    private $defaultIndexMethod;
 
-    public function __construct(string $tag)
+    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null)
     {
         parent::__construct([]);
 
         $this->tag = $tag;
+        $this->indexAttribute = $indexAttribute ?: null;
+
+        if ($indexAttribute) {
+            $this->defaultIndexMethod = $defaultIndexMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Name');
+        }
     }
 
     public function getTag()
     {
         return $this->tag;
+    }
+
+    public function getIndexAttribute(): ?string
+    {
+        return $this->indexAttribute;
+    }
+
+    public function getDefaultIndexMethod(): ?string
+    {
+        return $this->defaultIndexMethod;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added `%env(nullable:...)%` processor to allow empty variables to be processed as null values
  * added support for deprecating aliases
  * made `ContainerParametersResource` final and not implement `Serializable` anymore
+ * added ability to define an index for a tagged collection
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -31,18 +33,59 @@ trait PriorityTaggedServiceTrait
      * @see https://bugs.php.net/bug.php?id=53710
      * @see https://bugs.php.net/bug.php?id=60926
      *
-     * @param string           $tagName
-     * @param ContainerBuilder $container
+     * @param string|TaggedIteratorArgument $tagName
+     * @param ContainerBuilder              $container
      *
      * @return Reference[]
      */
     private function findAndSortTaggedServices($tagName, ContainerBuilder $container)
     {
+        $indexAttribute = $defaultIndexMethod = null;
+        if ($tagName instanceof TaggedIteratorArgument) {
+            $indexAttribute = $tagName->getIndexAttribute();
+            $defaultIndexMethod = $tagName->getDefaultIndexMethod();
+            $tagName = $tagName->getTag();
+        }
         $services = [];
 
         foreach ($container->findTaggedServiceIds($tagName, true) as $serviceId => $attributes) {
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
-            $services[$priority][] = new Reference($serviceId);
+
+            if (null === $indexAttribute) {
+                $services[$priority][] = new Reference($serviceId);
+
+                continue;
+            }
+
+            if (isset($attributes[0][$indexAttribute])) {
+                $services[$priority][$attributes[0][$indexAttribute]] = new Reference($serviceId);
+
+                continue;
+            }
+
+            if (!$r = $container->getReflectionClass($class = $container->getDefinition($serviceId)->getClass())) {
+                throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $serviceId));
+            }
+
+            if (!$r->hasMethod($defaultIndexMethod)) {
+                throw new InvalidArgumentException(sprintf('Method "%s::%s()" not found: tag "%s" on service "%s" is missing "%s" attribute.', $class, $defaultIndexMethod, $tagName, $serviceId, $indexAttribute));
+            }
+
+            if (!($rm = $r->getMethod($defaultIndexMethod))->isStatic()) {
+                throw new InvalidArgumentException(sprintf('Method "%s::%s()" should be static: tag "%s" on service "%s" is missing "%s" attribute.', $class, $defaultIndexMethod, $tagName, $serviceId, $indexAttribute));
+            }
+
+            if (!$rm->isPublic()) {
+                throw new InvalidArgumentException(sprintf('Method "%s::%s()" should be public: tag "%s" on service "%s" is missing "%s" attribute.', $class, $defaultIndexMethod, $tagName, $serviceId, $indexAttribute));
+            }
+
+            $key = $rm->invoke(null);
+
+            if (!\is_string($key)) {
+                throw new InvalidArgumentException(sprintf('Method "%s::%s()" should return a string, got %s: tag "%s" on service "%s" is missing "%s" attribute.', $class, $defaultIndexMethod, \gettype($key), $tagName, $serviceId, $indexAttribute));
+            }
+
+            $services[$priority][$key] = new Reference($serviceId);
         }
 
         if ($services) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
@@ -31,7 +31,7 @@ class ResolveTaggedIteratorArgumentPass extends AbstractRecursivePass
             return parent::processValue($value, $isRoot);
         }
 
-        $value->setValues($this->findAndSortTaggedServices($value->getTag(), $this->container));
+        $value->setValues($this->findAndSortTaggedServices($value, $this->container));
 
         return $value;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -286,6 +286,14 @@ class XmlDumper extends Dumper
             } elseif ($value instanceof TaggedIteratorArgument) {
                 $element->setAttribute('type', 'tagged');
                 $element->setAttribute('tag', $value->getTag());
+
+                if (null !== $value->getIndexAttribute()) {
+                    $element->setAttribute('index-by', $value->getIndexAttribute());
+                }
+
+                if (null !== $value->getDefaultIndexMethod()) {
+                    $element->setAttribute('default-index-method', $value->getDefaultIndexMethod());
+                }
             } elseif ($value instanceof IteratorArgument) {
                 $element->setAttribute('type', 'iterator');
                 $this->convertParameters($value->getValues(), $type, $element, 'key');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -233,6 +233,19 @@ class YamlDumper extends Dumper
         }
         if ($value instanceof ArgumentInterface) {
             if ($value instanceof TaggedIteratorArgument) {
+                if (null !== $value->getIndexAttribute()) {
+                    $taggedValueContent = [
+                        'tag' => $value->getTag(),
+                        'index_by' => $value->getIndexAttribute(),
+                    ];
+
+                    if (null !== $value->getDefaultIndexMethod()) {
+                        $taggedValueContent['default_index_method'] = $value->getDefaultIndexMethod();
+                    }
+
+                    return new TaggedValue('tagged', $taggedValueContent);
+                }
+
                 return new TaggedValue('tagged', $value->getTag());
             }
             if ($value instanceof IteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -116,9 +116,9 @@ function iterator(array $values): IteratorArgument
 /**
  * Creates a lazy iterator by tag name.
  */
-function tagged(string $tag): TaggedIteratorArgument
+function tagged(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null): TaggedIteratorArgument
 {
-    return new TaggedIteratorArgument($tag);
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod);
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -353,7 +353,7 @@ class XmlFileLoader extends FileLoader
                     continue;
                 }
 
-                if (false !== strpos($name, '-') && false === strpos($name, '_') && !array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
+                if (false !== strpos($name, '-') && false === strpos($name, '_') && !\array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
                     $parameters[$normalizedName] = XmlUtils::phpize($node->nodeValue);
                 }
                 // keep not normalized key
@@ -537,7 +537,8 @@ class XmlFileLoader extends FileLoader
                     if (!$arg->getAttribute('tag')) {
                         throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="tagged" has no or empty "tag" attribute in "%s".', $name, $file));
                     }
-                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'));
+
+                    $arguments[$key] = new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by') ?: null, $arg->getAttribute('default-index-method') ?: null);
                     break;
                 case 'binary':
                     if (false === $value = base64_decode($arg->nodeValue)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -710,11 +710,17 @@ class YamlFileLoader extends FileLoader
                 }
             }
             if ('tagged' === $value->getTag()) {
-                if (!\is_string($argument) || !$argument) {
-                    throw new InvalidArgumentException(sprintf('"!tagged" tag only accepts non empty string in "%s".', $file));
+                if (\is_string($argument) && $argument) {
+                    return new TaggedIteratorArgument($argument);
                 }
+                if (\is_array($argument) && isset($argument['name']) && $argument['name']) {
+                    if (array_diff(array_keys($argument), ['name', 'index_by', 'default_index_method'])) {
+                        throw new InvalidArgumentException('"!tagged" tag contains unsupported keys. Supported are: "name, index_by, default_index_method".');
+                    }
 
-                return new TaggedIteratorArgument($argument);
+                    return new TaggedIteratorArgument($argument['name'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null);
+                }
+                throw new InvalidArgumentException(sprintf('"!tagged" tag only accepts a non empty string or an array with a key "name" in "%s".', $file));
             }
             if ('service' === $value->getTag()) {
                 if ($isParameter) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -203,7 +203,7 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('The "services" key should contain an array in %s. Check your YAML syntax.', $file));
         }
 
-        if (array_key_exists('_instanceof', $content['services'])) {
+        if (\array_key_exists('_instanceof', $content['services'])) {
             $instanceof = $content['services']['_instanceof'];
             unset($content['services']['_instanceof']);
 
@@ -235,7 +235,7 @@ class YamlFileLoader extends FileLoader
      */
     private function parseDefaults(array &$content, string $file): array
     {
-        if (!array_key_exists('_defaults', $content['services'])) {
+        if (!\array_key_exists('_defaults', $content['services'])) {
             return [];
         }
         $defaults = $content['services']['_defaults'];
@@ -342,7 +342,7 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['alias'])) {
             $this->container->setAlias($id, $alias = new Alias($service['alias']));
-            if (array_key_exists('public', $service)) {
+            if (\array_key_exists('public', $service)) {
                 $alias->setPublic($service['public']);
             } elseif (isset($defaults['public'])) {
                 $alias->setPublic($defaults['public']);
@@ -430,7 +430,7 @@ class YamlFileLoader extends FileLoader
             $definition->setAbstract($service['abstract']);
         }
 
-        if (array_key_exists('deprecated', $service)) {
+        if (\array_key_exists('deprecated', $service)) {
             $definition->setDeprecated(true, $service['deprecated']);
         }
 
@@ -545,11 +545,11 @@ class YamlFileLoader extends FileLoader
             }
         }
 
-        if (array_key_exists('namespace', $service) && !array_key_exists('resource', $service)) {
+        if (\array_key_exists('namespace', $service) && !\array_key_exists('resource', $service)) {
             throw new InvalidArgumentException(sprintf('A "resource" attribute must be set when the "namespace" attribute is set for service "%s" in %s. Check your YAML syntax.', $id, $file));
         }
 
-        if (array_key_exists('resource', $service)) {
+        if (\array_key_exists('resource', $service)) {
             if (!\is_string($service['resource'])) {
                 throw new InvalidArgumentException(sprintf('A "resource" attribute must be of type string for service "%s" in %s. Check your YAML syntax.', $id, $file));
             }
@@ -713,14 +713,16 @@ class YamlFileLoader extends FileLoader
                 if (\is_string($argument) && $argument) {
                     return new TaggedIteratorArgument($argument);
                 }
-                if (\is_array($argument) && isset($argument['name']) && $argument['name']) {
-                    if (array_diff(array_keys($argument), ['name', 'index_by', 'default_index_method'])) {
-                        throw new InvalidArgumentException('"!tagged" tag contains unsupported keys. Supported are: "name, index_by, default_index_method".');
+
+                if (\is_array($argument) && isset($argument['tag']) && $argument['tag']) {
+                    if ($diff = array_diff(array_keys($argument), ['tag', 'index_by', 'default_index_method'])) {
+                        throw new InvalidArgumentException(sprintf('"!tagged" tag contains unsupported key "%s"; supported ones are "tag", "index_by" and "default_index_method".', implode('"", "', $diff)));
                     }
 
-                    return new TaggedIteratorArgument($argument['name'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null);
+                    return new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null);
                 }
-                throw new InvalidArgumentException(sprintf('"!tagged" tag only accepts a non empty string or an array with a key "name" in "%s".', $file));
+
+                throw new InvalidArgumentException(sprintf('"!tagged" tags only accept a non empty string or an array with a key "tag" in "%s".', $file));
             }
             if ('service' === $value->getTag()) {
                 if ($isParameter) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -234,6 +234,8 @@
     <xsd:attribute name="index" type="xsd:integer" />
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
     <xsd:attribute name="tag" type="xsd:string" />
+    <xsd:attribute name="index-by" type="xsd:string" />
+    <xsd:attribute name="default-index-method" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="call">

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
@@ -198,6 +199,19 @@ class XmlDumperTest extends TestCase
 
         $dumper = new XmlDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_dump_load.xml', $dumper->dump());
+    }
+
+    public function testTaggedArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'Foo')->addTag('foo_tag');
+        $container->register('foo_tagged_iterator', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar'))
+        ;
+
+        $dumper = new XmlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_tagged_arguments.xml', $dumper->dump());
     }
 
     public function testDumpAbstractServices()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -93,6 +94,16 @@ class YamlDumperTest extends TestCase
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_inline.yml', $dumper->dump());
+    }
+
+    public function testTaggedArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo_service', 'Foo')->addTag('foo');
+        $container->register('foo_service_tagged', 'Bar')->addArgument(new TaggedIteratorArgument('foo', 'barfoo', 'foobar'));
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_tagged_argument.yml', $dumper->dump());
     }
 
     private function assertEqualYamlStructure($expected, $yaml, $message = '')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTagClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarTagClass
+{
+    public static function getDefaultFooName()
+    {
+        return 'bar_tag_class';
+    }
+
+    public static function getFooBar()
+    {
+        return 'bar_tab_class_with_defaultmethod';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBarTaggedClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooBarTaggedClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooBarTaggedClass
+{
+    private $param;
+
+    public function __construct($param = [])
+    {
+        $this->param = $param;
+    }
+
+    public function getParam()
+    {
+        return $this->param;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooTagClass
+{
+    public static function getDefaultFooName()
+    {
+        return 'foo_tag_class';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Foo">
+      <tag name="foo_tag"/>
+    </service>
+    <service id="foo_tagged_iterator" class="Bar" public="true">
+      <argument type="tagged" tag="foo_tag" index-by="barfoo" default-index-method="foobar"/>
+    </service>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -1,0 +1,19 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service:
+        class: Foo
+        tags:
+            - { name: foo }
+    foo_service_tagged:
+        class: Bar
+        arguments: [!tagged { tag: foo, index_by: barfoo, default_index_method: foobar }]
+    Psr\Container\ContainerInterface:
+        alias: service_container
+        public: false
+    Symfony\Component\DependencyInjection\ContainerInterface:
+        alias: service_container
+        public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
@@ -313,6 +314,17 @@ class XmlFileLoaderTest extends TestCase
                 $this->assertArrayNotHasKey('an_other_option', $attributes, 'normalization should not be done when an underscore is already found');
             }
         }
+    }
+
+    public function testParseTaggedArgumentsWithIndexBy()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_with_tagged_arguments.xml');
+
+        $this->assertCount(1, $container->getDefinition('foo')->getTag('foo_tag'));
+        $this->assertCount(1, $container->getDefinition('foo_tagged_iterator')->getArguments());
+        $this->assertEquals(new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar'), $container->getDefinition('foo_tagged_iterator')->getArgument(0));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -277,6 +278,17 @@ class YamlFileLoaderTest extends TestCase
             $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if a tag is missing the name key');
             $this->assertStringStartsWith('A "tags" entry is missing a "name" key for service ', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag is missing the name key');
         }
+    }
+
+    public function testTaggedArgumentsWithIndex()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_tagged_argument.yml');
+
+        $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged')->getArguments());
+        $this->assertEquals(new TaggedIteratorArgument('foo', 'barfoo', 'foobar'), $container->getDefinition('foo_service_tagged')->getArgument(0));
     }
 
     public function testNameOnlyTagsAreAllowedAsString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yno
| Tests pass?   | yes
| Fixed tickets | # 29203
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is the continuity of the PR # 

Add a way to specify an index based on a tag attribute when injecting a tag collection into services, but also a a way to fallback to a static method on the service class.

```yaml
services:
  foo_service:
    class: Foo
    tags:
      - foo
  foo_service_tagged:
    class: Bar
    arguments:
      - !tagged { tag: 'foo'', index_by: 'tag_attribute_name', default_index_method: 'static_method'}
```
```xml
<?xml version="1.0" ?>

<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
  <services>
    <service id="foo" class="Foo">
        <tag name="foo_tag" />
    </service>
    <service id="foo_tagged_iterator" class="Bar" public="true">
      <argument type="tagged" tag="foo_tag" index-by="tag_attribute_name" default-index-method="static_method" />
    </service>
  </services>
</container>
```

Tasks

* [x]  Support PHP loader/dumper
* [x]  Support YAML loader/dumper
* [x]  Support XML loader/dumper (and update XSD too)
* [x]  Add tests
