### PR TITLE
[DI] Allow tagged_locator tag to be used as an argument

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
+use Symfony\Component\DependencyInjection\Reference;
+
 /**
  * Represents a closure acting as a service locator.
  *
@@ -19,4 +21,24 @@ namespace Symfony\Component\DependencyInjection\Argument;
 class ServiceLocatorArgument implements ArgumentInterface
 {
     use ReferenceSetArgumentTrait;
+
+    private $taggedIteratorArgument;
+
+    /**
+     * @param Reference[]|TaggedIteratorArgument $values
+     */
+    public function __construct($values = [])
+    {
+        if ($values instanceof TaggedIteratorArgument) {
+            $this->taggedIteratorArgument = $values;
+            $this->values = [];
+        } else {
+            $this->setValues(values);
+        }
+    }
+
+    public function getTaggedIteratorArgument(): ?TaggedIteratorArgument
+    {
+        return $this->taggedIteratorArgument;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -23,8 +23,6 @@ class TaggedIteratorArgument extends IteratorArgument
     private $defaultIndexMethod;
 
     /**
-     * TaggedIteratorArgument constructor.
-     *
      * @param string      $tag                The name of the tag identifying the target services
      * @param string|null $indexAttribute     The name of the attribute that defines the key referencing each service in the tagged collection
      * @param string|null $defaultIndexMethod The static method that should be called to get each service's key when their tag doesn't define the previous attribute

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * added support for deprecating aliases
  * made `ContainerParametersResource` final and not implement `Serializable` anymore
  * added ability to define an index for a tagged collection
+ * added ability to define an index for services in an injected service locator argument
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -27,11 +27,18 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 final class ServiceLocatorTagPass extends AbstractRecursivePass
 {
+    use PriorityTaggedServiceTrait;
+
     protected function processValue($value, $isRoot = false)
     {
         if ($value instanceof ServiceLocatorArgument) {
+            if ($value->getTaggedIteratorArgument()) {
+                $value->setValues($this->findAndSortTaggedServices($value->getTaggedIteratorArgument(), $this->container));
+            }
+
             return self::register($this->container, $value->getValues());
         }
+
         if (!$value instanceof Definition || !$value->hasTag('container.service_locator')) {
             return parent::processValue($value, $isRoot);
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -298,8 +298,18 @@ class XmlDumper extends Dumper
                 $element->setAttribute('type', 'iterator');
                 $this->convertParameters($value->getValues(), $type, $element, 'key');
             } elseif ($value instanceof ServiceLocatorArgument) {
-                $element->setAttribute('type', 'service_locator');
-                $this->convertParameters($value->getValues(), $type, $element, 'key');
+                if ($value->getTaggedIteratorArgument()) {
+                    $element->setAttribute('type', 'tagged_locator');
+                    $element->setAttribute('tag', $value->getTaggedIteratorArgument()->getTag());
+                    $element->setAttribute('index-by', $value->getTaggedIteratorArgument()->getIndexAttribute());
+
+                    if (null !== $value->getTaggedIteratorArgument()->getDefaultIndexMethod()) {
+                        $element->setAttribute('default-index-method', $value->getTaggedIteratorArgument()->getDefaultIndexMethod());
+                    }
+                } else {
+                    $element->setAttribute('type', 'service_locator');
+                    $this->convertParameters($value->getValues(), $type, $element, 'key');
+                }
             } elseif ($value instanceof Reference) {
                 $element->setAttribute('type', 'service');
                 $element->setAttribute('id', (string) $value);

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -252,6 +252,18 @@ class YamlDumper extends Dumper
                 $tag = 'iterator';
             } elseif ($value instanceof ServiceLocatorArgument) {
                 $tag = 'service_locator';
+                if ($value->getTaggedIteratorArgument()) {
+                    $taggedValueContent = [
+                        'tag' => $value->getTaggedIteratorArgument()->getTag(),
+                        'index_by' => $value->getTaggedIteratorArgument()->getIndexAttribute(),
+                    ];
+
+                    if (null !== $value->getTaggedIteratorArgument()->getDefaultIndexMethod()) {
+                        $taggedValueContent['default_index_method'] = $value->getTaggedIteratorArgument()->getDefaultIndexMethod();
+                    }
+
+                    return new TaggedValue('tagged_locator', $taggedValueContent);
+                }
             } else {
                 throw new RuntimeException(sprintf('Unspecified Yaml tag for type "%s".', \get_class($value)));
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -122,6 +122,14 @@ function tagged(string $tag, string $indexAttribute = null, string $defaultIndex
 }
 
 /**
+ * Creates a service locator by tag name.
+ */
+function tagged_locator(string $tag, string $indexAttribute, string $defaultIndexMethod = null): ServiceLocatorArgument
+{
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod));
+}
+
+/**
  * Creates an expression.
  */
 function expr(string $expression): Expression

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -533,6 +533,13 @@ class XmlFileLoader extends FileLoader
                         throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="service_locator" only accepts maps of type="service" references in "%s".', $name, $file));
                     }
                     break;
+                case 'tagged_locator':
+                    if (!$arg->getAttribute('tag') || !$arg->getAttribute('index-by')) {
+                        throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="tagged_locator" has no or empty "tag" or "index-by" attributes in "%s".', $name, $file));
+                    }
+
+                    $arguments[$key] = new ServiceLocatorArgument(new TaggedIteratorArgument($arg->getAttribute('tag'), $arg->getAttribute('index-by'), $arg->getAttribute('default-index-method') ?: null));
+                    break;
                 case 'tagged':
                     if (!$arg->getAttribute('tag')) {
                         throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="tagged" has no or empty "tag" attribute in "%s".', $name, $file));

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -702,7 +702,9 @@ class YamlFileLoader extends FileLoader
                 if (!\is_array($argument)) {
                     throw new InvalidArgumentException(sprintf('"!service_locator" tag only accepts maps in "%s".', $file));
                 }
+
                 $argument = $this->resolveServices($argument, $file, $isParameter);
+
                 try {
                     return new ServiceLocatorArgument($argument);
                 } catch (InvalidArgumentException $e) {
@@ -723,6 +725,17 @@ class YamlFileLoader extends FileLoader
                 }
 
                 throw new InvalidArgumentException(sprintf('"!tagged" tags only accept a non empty string or an array with a key "tag" in "%s".', $file));
+            }
+            if ('tagged_locator' === $value->getTag()) {
+                if (\is_array($argument) && isset($argument['tag'], $argument['index_by']) && $argument['tag'] && $argument['index_by']) {
+                    if ($diff = array_diff(array_keys($argument), ['tag', 'index_by', 'default_index_method'])) {
+                        throw new InvalidArgumentException(sprintf('"!tagged_locator" tag contains unsupported key "%s"; supported ones are "tag", "index_by" and "default_index_method".', implode('"", "', $diff)));
+                    }
+
+                    return new ServiceLocatorArgument(new TaggedIteratorArgument($argument['tag'], $argument['index_by'], $argument['default_index_method'] ?? null));
+                }
+
+                throw new InvalidArgumentException(sprintf('"!tagged_locator" tags only accept an array with at least keys "tag" and "index_by" in "%s".', $file));
             }
             if ('service' === $value->getTag()) {
                 if ($isParameter) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -264,6 +264,7 @@
       <xsd:enumeration value="iterator" />
       <xsd:enumeration value="service_locator" />
       <xsd:enumeration value="tagged" />
+      <xsd:enumeration value="tagged_locator" />
     </xsd:restriction>
   </xsd:simpleType>
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -93,6 +93,6 @@ class PriorityTaggedServiceTraitImplementation
 
     public function test($tagName, ContainerBuilder $container)
     {
-        return $this->findAndSortTaggedServices($tagName, $container);
+        return self::findAndSortTaggedServices($tagName, $container);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -201,13 +202,18 @@ class XmlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_dump_load.xml', $dumper->dump());
     }
 
-    public function testTaggedArgument()
+    public function testTaggedArguments()
     {
+        $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar');
         $container = new ContainerBuilder();
         $container->register('foo', 'Foo')->addTag('foo_tag');
         $container->register('foo_tagged_iterator', 'Bar')
             ->setPublic(true)
-            ->addArgument(new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar'))
+            ->addArgument($taggedIterator)
+        ;
+        $container->register('foo_tagged_locator', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new ServiceLocatorArgument($taggedIterator))
         ;
 
         $dumper = new XmlDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -96,11 +97,13 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_inline.yml', $dumper->dump());
     }
 
-    public function testTaggedArgument()
+    public function testTaggedArguments()
     {
+        $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar');
         $container = new ContainerBuilder();
         $container->register('foo_service', 'Foo')->addTag('foo');
-        $container->register('foo_service_tagged', 'Bar')->addArgument(new TaggedIteratorArgument('foo', 'barfoo', 'foobar'));
+        $container->register('foo_service_tagged_iterator', 'Bar')->addArgument($taggedIterator);
+        $container->register('foo_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator));
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_tagged_argument.yml', $dumper->dump());

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
@@ -8,6 +8,9 @@
     <service id="foo_tagged_iterator" class="Bar" public="true">
       <argument type="tagged" tag="foo_tag" index-by="barfoo" default-index-method="foobar"/>
     </service>
+    <service id="foo_tagged_locator" class="Bar" public="true">
+      <argument type="tagged_locator" tag="foo_tag" index-by="barfoo" default-index-method="foobar"/>
+    </service>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -8,9 +8,12 @@ services:
         class: Foo
         tags:
             - { name: foo }
-    foo_service_tagged:
+    foo_service_tagged_iterator:
         class: Bar
         arguments: [!tagged { tag: foo, index_by: barfoo, default_index_method: foobar }]
+    foo_service_tagged_locator:
+        class: Bar
+        arguments: [!tagged_locator { tag: foo, index_by: barfoo, default_index_method: foobar }]
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -324,7 +325,11 @@ class XmlFileLoaderTest extends TestCase
 
         $this->assertCount(1, $container->getDefinition('foo')->getTag('foo_tag'));
         $this->assertCount(1, $container->getDefinition('foo_tagged_iterator')->getArguments());
-        $this->assertEquals(new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar'), $container->getDefinition('foo_tagged_iterator')->getArgument(0));
+        $this->assertCount(1, $container->getDefinition('foo_tagged_locator')->getArguments());
+
+        $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar');
+        $this->assertEquals($taggedIterator, $container->getDefinition('foo_tagged_iterator')->getArgument(0));
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_tagged_locator')->getArgument(0));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
@@ -287,8 +288,12 @@ class YamlFileLoaderTest extends TestCase
         $loader->load('services_with_tagged_argument.yml');
 
         $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
-        $this->assertCount(1, $container->getDefinition('foo_service_tagged')->getArguments());
-        $this->assertEquals(new TaggedIteratorArgument('foo', 'barfoo', 'foobar'), $container->getDefinition('foo_service_tagged')->getArgument(0));
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_iterator')->getArguments());
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_locator')->getArguments());
+
+        $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar');
+        $this->assertEquals($taggedIterator, $container->getDefinition('foo_service_tagged_iterator')->getArgument(0));
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
     }
 
     public function testNameOnlyTagsAreAllowedAsString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | in progress /  symfony/symfony-docs#... 

Add a way to specify an index based on a tag attribute to simplify retrieve a specific service when injecting a service locator as argument into services, but also a a way to fallback to a static method on the service class.

It's more or less the same thing then the 30257 but for service locator argument
Yaml:
```yaml
services:
  foo_service:
    class: Foo
    tags:
      - {name: foo_tag, key: foo_service}
  foo_service_tagged:
    class: Bar
    arguments:
      - !tagged_locator
          tag: 'foo_tag'
          index_by: 'key'
          default_index_method: 'static_method'
```
XML:
```xml
<?xml version="1.0" ?>

<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services
    http://symfony.com/schema/dic/services/services-1.0.xsd">
  <services>
    <service id="foo" class="Foo">
        <tag name="foo_tag" key="foo_service" />
    </service>
    <service id="foo_tagged_iterator" class="Bar" public="true">
      <argument type="tagged_locator" tag="foo_tag" index-by="key" default-index-method="static_method" />
    </service>
  </services>
</container>
```
PHP:
```php
// config/services.php
use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;

$container->register(Foo::class)
        ->addTag('foo_tag', ['key' => 'foo_service']);

$container->register(App\Handler\HandlerCollection::class)
         // inject all services tagged with app.handler as first argument
         ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('app.handler', 'key')));
```

Usage: 
```php
// src/Handler/HandlerCollection.php
namespace App\Handler;

use Symfony\Component\DependencyInjection\ServiceLocator;

class HandlerCollection
{
     public function __construct(ServiceLocator $serviceLocator)
     {
           $foo = $serviceLocator->get('foo_service'):
     }
}
```

Tasks

* [x]  Support PHP loader/dumper
* [x]  Support YAML loader/dumper
* [x]  Support XML loader/dumper (and update XSD too)
* [x]  Add tests
* [x]  Documentation
